### PR TITLE
margin between text box and image

### DIFF
--- a/src/app/styles/whoTitle.module.css
+++ b/src/app/styles/whoTitle.module.css
@@ -89,6 +89,7 @@
 
 .textbox {
   padding: 20px;
+  margin-top: 10px;
   width: 75%;
   height: 20%;
   resize: both;


### PR DESCRIPTION
add space between text input and generated image, make it easier for screengrabs.